### PR TITLE
Fix unreadable text when bg is blurred

### DIFF
--- a/obsidian.css
+++ b/obsidian.css
@@ -153,7 +153,7 @@
 html,
 body,
 .app-container {
-  backdrop-filter: blur(5px);
+  backdrop-filter: blur(30px) contrast(100%);
   background: radial-gradient(
       ellipse at top,
       var(--background-light),
@@ -203,7 +203,7 @@ kbd.suggestion-hotkey {
 
 .modal-bg {
   background-color: #ffffff01;
-  backdrop-filter: blur(30px);
+  backdrop-filter: blur(25px) brightness(65%);
 }
 
 /* Make legible background for menus since we overrode the background */

--- a/obsidian.css
+++ b/obsidian.css
@@ -153,7 +153,7 @@
 html,
 body,
 .app-container {
-  backdrop-filter: blur(30px) contrast(100%);
+  backdrop-filter: blur(5px);
   background: radial-gradient(
       ellipse at top,
       var(--background-light),


### PR DESCRIPTION
Small fix due to unreadable text in dark mode with white objects in background.

![image](https://user-images.githubusercontent.com/44808485/101492814-7efe3080-3965-11eb-855e-fd26f25338e1.png)


